### PR TITLE
Release version 20210517.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ debian/files
 debian/maratona-submission.debhelper.log
 debian/maratona-submission.substvars
 debian/maratona-submission/
+debian/debhelper-build-stamp

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,15 @@
+maratona-submission (20210517.1) focal; urgency=medium
+
+  * Remove and ignore build artifacts
+  * Update maintainer, description and add VCS info
+    - updates maintainer's name and email
+    - adds VCS details
+    - adds extended description (fixes error extended-description-is-empty,
+      see issue #2 for more details)
+  * Update machine-readable copyright file
+
+ -- Davi Antônio da Silva Santos <antoniossdavi@gmail.com>  Mon, 28 Jun 2021 21:09:05 -0300
+
 maratona-submission (20210517) focal; urgency=medium
 
   * Update .gitignore

--- a/debian/control
+++ b/debian/control
@@ -1,10 +1,15 @@
 Source: maratona-submission
 Section: misc
 Priority: optional
-Maintainer: Bruno Ribas <brunoribas@utfpr.edu.br>
+Maintainer: Bruno César Ribas <bruno.ribas@unb.br>
 Build-Depends: debhelper-compat (= 12)
+Vcs-Git: https://github.com/maratona-linux/maratona-submission.git
+Vcs-Browser: https://github.com/maratona-linux/maratona-submission
 
 Package: maratona-submission
 Architecture: all
 Depends: maratona-firewall, boca-submission-tools, maratona-usuario-icpc
 Description: Pacote com o ambiente de submissão para o Boca central
+ Este pacote instala dependências que modificam o sistema base do Ubuntu,
+ instalando um usuário específico para o Maratona, restringindo o tráfego de
+ rede e configurando o ambiente de submissão de soluções.

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,14 +1,10 @@
 Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
-Upstream-Name: maratona-background
-Source: <url://example.com>
+Upstream-Name: maratona-submission
+Source: <https://github.com/maratona-linux/maratona-submission>
 
 Files: *
-Copyright: <years> <put author's name and email here>
-           <years> <likewise for another author>
-License: GPL-2.0+
-
-Files: debian/*
-Copyright: 2016 Bruno Ribas <brunoribas@utfpr.edu.br>
+Copyright: 2016-2021 Bruno César Ribas <bruno.ribas@unb.br>
+           2021 Davi Antônio da Silva Santos <antoniossdavi@gmail.com>
 License: GPL-2.0+
 
 License: GPL-2.0+
@@ -27,8 +23,3 @@ License: GPL-2.0+
  .
  On Debian systems, the complete text of the GNU General
  Public License version 2 can be found in "/usr/share/common-licenses/GPL-2".
-
-# Please also look if there are files or directories which have a
-# different copyright/license attached and list them here.
-# Please avoid picking licenses with terms that are more restrictive than the
-# packaged work, as it may make Debian's contributions unacceptable upstream.

--- a/debian/debhelper-build-stamp
+++ b/debian/debhelper-build-stamp
@@ -1,1 +1,0 @@
-maratona-submission


### PR DESCRIPTION
* Remove and ignore build artifacts
  - update `.gitignore`
* Update maintainer, description and add VCS info
  - updates maintainer's name and email
  - adds VCS details
  - adds extended description (fixes error extended-description-is-empty,
    see issue #2 for more details)
* Update machine-readable copyright file
  - update `debian/copyright`